### PR TITLE
Posts padding

### DIFF
--- a/_includes/styles.html
+++ b/_includes/styles.html
@@ -159,6 +159,7 @@ footer a {
 /* -- POSTS -- */
 ul.posts {
   list-style:none;
+  margin-top:1.5em;
 }
 ul.posts li a {
   text-decoration:none;

--- a/_includes/styles.html
+++ b/_includes/styles.html
@@ -123,16 +123,17 @@ header {
   100%{background-position:0% 47%}
 }
 header:after {
-  content:"";
-  width: 40px;
-  height: 40px;
-  position:absolute;
-  left:50%;
-  right:50%;
-  bottom:-20px;
-  margin-left:-20px;
-  transform: rotate(45deg);
-  background: rgba(255,255,255,1);
+  content: "";
+  width: 0;
+  height: 0;
+  position: absolute;
+  left: 50%;
+  right: 50%;
+  bottom: 0;
+  margin-left: -28px;
+  border-bottom: 28px solid #fff;
+  border-left: 28px solid transparent;
+  border-right: 28px solid transparent;
 }
 header h1, header p  {
   text-align:center;


### PR DESCRIPTION
### What does this PR do?
- Increases the padding at the top of the posts (home) page.

### What is the issue your trying to solve?
![screen shot 2015-02-19 at 12 24 49](https://cloud.githubusercontent.com/assets/778942/6266494/51d62c94-b832-11e4-855b-983bde4bd09d.png)
- The styling (white up arrow, which is actually a square, not sure why) overlaps the content below.
- A quick fix just adds padding, I don't have the time (just yet) to change this to a triangle.

### Reviewing

#### Quality checklist (for PR author to complete BEFORE code review):
- [x] I've updated documentation with any changes to procedures.
- [x] I've tested this on mobile Android, Safari, Chrome for any visual changes.
- [x] I am ready for this to be code reviewed, merged and tested.

#### IP or Developer Review:
- [x] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for coding anti-patterns.
- [x] +1 from me!

#### Software Engineer, Software Architect or Developer review:
- [x] I’ve witnessed the work behaving as expected.
- [x] I’ve checked for coding anti-patterns.
- [x] +1 from me!