### PR TITLE
Fix navigation highlighting on team page

### DIFF
--- a/team/index.html
+++ b/team/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: The Holiday Extras Tech Team
+category: team
 ---
 <div class="team">
   <header>


### PR DESCRIPTION
#### What does this PR do?
Changes this 
![](https://cldup.com/3XLnxvBh6H.png)
to this
![](https://cldup.com/WfQyjHL02S.png)
when on the team page.
#### How should this be manually tested?
Run `jekyll serve` on this branch, check that when you visit the team page you see the link in the nav highlighted.
#### What gif best describes how you feel about this work?
![](http://media2.giphy.com/media/9kDR0U4gaguic/giphy.gif)
---
#### IP or Developer Review:
- [x] I’ve witnessed the work behaving as expected.
- [x] +1 from me!

#### Software Engineer or Developer review:
- [x] I’ve witnessed the work behaving as expected.
- [x] +1 from me!