### PR TITLE
Changed "Testing" to "testing" on three of my articles

### DIFF
--- a/_posts/2015-08-19-checking-and-exploring.md
+++ b/_posts/2015-08-19-checking-and-exploring.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Checking & Exploring in Software Testing
-categories: Testing
+categories: testing
 author: matt_obee
 tags: testing checking exploring
 comments: true

--- a/_posts/2015-10-05-10-myths-about-software-testing.md
+++ b/_posts/2015-10-05-10-myths-about-software-testing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 10 Myths about Software Testing
-categories: Testing
+categories: testing
 author: matt_obee
 tags: testing
 comments: true

--- a/_posts/2015-12-18-testing-for-accessibility.md
+++ b/_posts/2015-12-18-testing-for-accessibility.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: An Introduction to Testing for Accessibility
-categories: Testing
+categories: testing
 author: matt_obee
 tags: testing accessibility
 comments: true


### PR DESCRIPTION
The new Atom feed that I created in #88 looks for articles in the (lowercase) "testing" category but three of my previous articles are in the (uppercase) "Testing" category. This PR changes "Testing" to "testing" on those three articles so that they appear correctly in the Atom feed.