### PR TITLE
Blog post about the recent changes in the PO group role titles and profiles

### DIFF
--- a/_posts/2016-05-18-the-group-formerly-known-as-pos.md
+++ b/_posts/2016-05-18-the-group-formerly-known-as-pos.md
@@ -3,9 +3,8 @@ comments: "true"
 layout: post
 published: false
 title: The group formerly known as POs
-author: ""
-categories: ""
-tags: ""
+author: Alix George
+categories: "Managing people, Product Owner, Scrum, Roles"
 ---
 ## Changing role titles and profiles
 

--- a/_posts/2016-05-18-the-group-formerly-known-as-pos.md
+++ b/_posts/2016-05-18-the-group-formerly-known-as-pos.md
@@ -4,13 +4,15 @@ layout: post
 published: false
 title: The group formerly known as POs
 author: Alix George
-categories: "Managing people, Product Owner, Scrum, Roles"
+categories: "Product Owner, Pod Lead"
+tags: "Managing people, scrum, roles"
+
 ---
 ## Changing role titles and profiles
 
-I was asked recently why we've made some recent changes to some of the role titles and profiles for some of the group formerly known as the Product Owners. To best answer, I decided to write a blog post about it.
+I was asked recently why we've made some changes to some of the role titles and profiles for some of the group formerly known as the Product Owners. To best answer, I decided to write a blog post about it.
 
-The main reason behind the changes was to set them up for success. That can sound a bit cliche but it's something I say often in my role - management is about setting people up for success. If someone is in the right role with the right expectations, it's great for them, their development and growth, and great for the business.
+The main reason behind the changes was to set them up for success. That can sound a bit cliche but it's something I say often in my role - management is about setting people up for success. If someone is in the right role with the right expectations, it's great for them, their development and growth, and great for the business. 
 
 So were the former role titles _wrong_? 
 
@@ -20,7 +22,7 @@ When the Web team started fully following scrum practices, the leads of each tea
 
 We had a shared role profile that outlined what 'great' looks like for a PO, which listed qualities we need, responsibilities in the role and the approach required to deliver against those responsibilities successfully. 
 
-I became a Product Owner in January 2015 and then Lead Product Owner in October the same year - when I began managing the other PO's, it was clear that what was great for one PO wasn't the same as for another.
+I became a Product Owner in January 2015 and then Lead Product Owner in October the same year - when I began managing the other PO's, it was clear that what was great for one PO wasn't the same for another.
 
 The first thing that I experienced was that some of the Product Owners' had different responsibilities. Some could focus all of their time and attention on the product they were leading on, whereas others' time was split in different directions because of their specialisms or business experience.
 
@@ -44,4 +46,4 @@ We now have a UK Delivery Manager, an EU Delivery Manager and a Technical Produc
 
 I'm still working on my own role title - Lead Pod Lead, Pod Lead Lead, and PodLeady McLeadFace have been the suggestions (and rejections... not a poll, guys...) so far.
 
-This is one of the things I love about Holiday Extras - you try something, you evolve it, try something different until you find what works best (and even then, you keep trying!).
+This is one of the things I love about Holiday Extras - you try something, you evolve it, try something different until you find what works better (and even then, you keep trying!).

--- a/_posts/2016-05-18-the-group-formerly-known-as-pos.md
+++ b/_posts/2016-05-18-the-group-formerly-known-as-pos.md
@@ -12,7 +12,7 @@ tags: "Managing people, scrum, roles"
 
 I was asked recently why we've made some changes to some of the role titles and profiles for some of the group formerly known as the Product Owners. To best answer, I decided to write a blog post about it.
 
-The main reason behind the changes was to set them up for success. That can sound a bit cliche but it's something I say often in my role - management is about setting people up for success. If someone is in the right role with the right expectations, it's great for them, their development and growth, and great for the business. 
+The main reason behind the changes was to set them up for success. That can sound a bit clichéd but it's something I say often in my role - management is about setting people up for success. If someone is in the right role with the right expectations, it's great for them, their development and growth, and great for the business. 
 
 So were the former role titles _wrong_? 
 

--- a/_posts/2016-05-18-the-group-formerly-known-as-pos.md
+++ b/_posts/2016-05-18-the-group-formerly-known-as-pos.md
@@ -1,0 +1,48 @@
+---
+comments: "true"
+layout: post
+published: false
+title: The group formerly known as POs
+author: ""
+categories: ""
+tags: ""
+---
+## Changing role titles and profiles
+
+I was asked recently why we've made some recent changes to some of the role titles and profiles for some of the group formerly known as the Product Owners. To best answer, I decided to write a blog post about it.
+
+The main reason behind the changes was to set them up for success. That can sound a bit cliche but it's something I say often in my role - management is about setting people up for success. If someone is in the right role with the right expectations, it's great for them, their development and growth, and great for the business.
+
+So were the former role titles _wrong_? 
+
+Not exactly. 
+
+When the Web team started fully following scrum practices, the leads of each team (or pods as we call them at Holiday Extras) became Product Owners as per the framework. As a collective, we were known as the PO group.
+
+We had a shared role profile that outlined what 'great' looks like for a PO, which listed qualities we need, responsibilities in the role and the approach required to deliver against those responsibilities successfully. 
+
+I became a Product Owner in January 2015 and then Lead Product Owner in October the same year - when I began managing the other PO's, it was clear that what was great for one PO wasn't the same as for another.
+
+The first thing that I experienced was that some of the Product Owners' had different responsibilities. Some could focus all of their time and attention on the product they were leading on, whereas others' time was split in different directions because of their specialisms or business experience.
+
+That would be fine except that it put a lot of pressure on those who had a myriad of other responsibilities outside the realms of the PO role. There was a perception from some that they weren't delivering against the PO role properly because their time was being demanded elsewhere. These were high-performing people who were getting stressed because, as it was emerging, the business expected one thing but their role profile expected another.
+
+The second thing was that, in some cases, the role title of Product Owner was inaccurate. The role literally means that you own a product - the vision, the prioritisation, the roadmap, the delivery. 
+
+At Holiday Extras, we have pods that are based around a mixture of metrics, platforms and products. For example, the Conversion pod is based around - you guessed it - delivering increased conversion rate; whereas the Trading pod's focus is on the day-to-day trading of the business. The former can have a fairly robust roadmap of key things the pod is going to do whereas the latter changes on a Sprint by Sprint basis. 
+
+This links to my first point about expectations, i.e. if your pod has to be reactive by it's very nature, can your success as a PO really be measured by responsibilities like product iteration?  
+
+The main point here is that each of those in the former PO group was on a sliding scale between Project Management, Product Management and Product Ownership. If the business was expecting one of the POs to lead a high value, technically complex, time critical project that didn't fit into the pod's focus, it needed to be reflected in the role titles and profiles. 
+
+It's an evolution - we started with all of us having the same title and the same expectations, and as with everything, once we got going, we could see there were differences that needed to be acknowledged.
+
+From my side, I wanted to make sure that I was managing these individuals properly too. I wanted to make sure that people felt clear and confident in what was expected of them and that I could support them in the right way to do those things.
+
+Speaking to the individuals was an important part of this adjustment - and as of this week, we've nearly finished firming up their role profiles. 
+
+We now have a UK Delivery Manager, an EU Delivery Manager and a Technical Product Manager and to reflect the mix of roles, the PO group is now known as the Pod Leads. I see this as being the start of identifying what 'great' looks like for each Lead for each pod.
+
+I'm still working on my own role title - Lead Pod Lead, Pod Lead Lead, and PodLeady McLeadFace have been the suggestions (and rejections... not a poll, guys...) so far.
+
+This is one of the things I love about Holiday Extras - you try something, you evolve it, try something different until you find what works best (and even then, you keep trying!).

--- a/_posts/2016-05-18-the-group-formerly-known-as-pos.md
+++ b/_posts/2016-05-18-the-group-formerly-known-as-pos.md
@@ -24,7 +24,7 @@ I became a Product Owner in January 2015 and then Lead Product Owner in October 
 
 The first thing that I experienced was that some of the Product Owners' had different responsibilities. Some could focus all of their time and attention on the product they were leading on, whereas others' time was split in different directions because of their specialisms or business experience.
 
-That would be fine except that it put a lot of pressure on those who had a myriad of other responsibilities outside the realms of the PO role. There was a perception from some that they weren't delivering against the PO role properly because their time was being demanded elsewhere. These were high-performing people who were getting stressed because, as it was emerging, the business expected one thing but their role profile expected another.
+That would be fine except that it put a lot of pressure on those who had a myriad of other responsibilities outside the realms of the PO role. There was a perception from some that they weren't delivering against the PO role properly because their time was being demanded elsewhere. These were high-performing people who were getting concerned because, as it was emerging, the business expected one thing but their role profile expected another.
 
 The second thing was that, in some cases, the role title of Product Owner was inaccurate. The role literally means that you own a product - the vision, the prioritisation, the roadmap, the delivery. 
 


### PR DESCRIPTION
### The group formerly known as POs

### Blog about why we made the recent role title and profile changes within the Pod Lead group.

#### Author
- [x] I have checked for grammatical errors
- [x] I have checked for spelling errors
- [x] All information (technical or otherwise) is correct to my knowledge

#### Editor 1
- [x] I have checked for grammatical errors
- [x] I have checked for spelling errors
- [x] All information (technical or otherwise) is correct to my knowledge

#### Editor 2
- [x] I have checked for grammatical errors
- [x] I have checked for spelling errors
- [x] All information (technical or otherwise) is correct to my knowledge