### PR TITLE
Adding more of our open source projects

### DIFF
--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -21,7 +21,77 @@ category: project
           </section>
         </a>
       </li>
-       <li>
+      <li>
+        <a href="https://github.com/holidayextras/jsonapi-server/">
+          <section>
+            <h2>jsonapi-server</h2>
+            <div class="project-summary">
+              <blockquote>A config driven NodeJS framework implementing json:api.</blockquote>
+            </div>
+          </section>
+        </a>
+      </li>
+      <li>
+        <a href="https://github.com/holidayextras/jsonapi-client/">
+          <section>
+            <h2>jsonapi-client</h2>
+            <div class="project-summary">
+              <blockquote>Easily consume a json:api service in Javascript.</blockquote>
+            </div>
+          </section>
+        </a>
+      </li>
+      <li>
+        <a href="https://github.com/holidayextras/jsonapi-store-mongodb">
+          <section>
+            <h2>jsonapi-store-mongodb</h2>
+            <div class="project-summary">
+              <blockquote>A mongodb database handler for jsonapi-server.</blockquote>
+            </div>
+          </section>
+        </a>
+      </li>
+      <li>
+        <a href="https://github.com/holidayextras/jsonapi-store-relationaldb">
+          <section>
+            <h2>jsonapi-store-relationaldb</h2>
+            <div class="project-summary">
+              <blockquote>A relational database handler for jsonapi-server.</blockquote>
+            </div>
+          </section>
+        </a>
+      </li>
+      <li>
+        <a href="https://github.com/holidayextras/jsonapi-store-elasticsearch">
+          <section>
+            <h2>jsonapi-store-elasticsearch</h2>
+            <div class="project-summary">
+              <blockquote>An elasticsearch handler for jsonapi-server.</blockquote>
+            </div>
+          </section>
+        </a>
+      </li>
+      <li>
+        <a href="https://github.com/holidayextras/hxMetrics">
+          <section>
+            <h2>HXMetrics</h2>
+            <div class="project-summary">
+              <blockquote>Instrument NodeJS modules without touching their source code.</blockquote>
+            </div>
+          </section>
+        </a>
+      </li>
+      <li>
+        <a href="http://tech.holidayextras.co.uk/ui-toolkit/">
+          <section>
+            <h2>UI-Toolkit</h2>
+            <div class="project-summary">
+              <blockquote>A set of CSS &amp; React components in a handy toolkit.</blockquote>
+            </div>
+          </section>
+        </a>
+      </li>
+      <li>
         <a href="https://github.com/holidayextras/WorkerJS/">
           <section>
             <h2>Worker.js</h2>


### PR DESCRIPTION
I've added a whole bunch of our open source projects to the projects page, including:
- jsonapi-server
- jsonapi-client
- jsonapi-store-relationaldb
- jsonapi-store-mongodb
- jsonapi-store-elasticsearch
- hxMetrics
- ui-toolkit

I've lifted the GitHub repo title's as the text for each tile.
#### Author
- [x] I have checked for grammatical errors
- [x] I have checked for spelling errors
- [x] All information (technical or otherwise) is correct to my knowledge
#### Editor 1
- [ ] I have checked for grammatical errors
- [ ] I have checked for spelling errors
- [ ] All information (technical or otherwise) is correct to my knowledge
#### Editor 2
- [ ] I have checked for grammatical errors
- [ ] I have checked for spelling errors
- [ ] All information (technical or otherwise) is correct to my knowledge
