### PR TITLE
Added link in projects to UI-Toolkit

### DIFF
--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -81,6 +81,16 @@ category: project
           </section>
         </a>
       </li>
+      <li>
+        <a href="http://tech.holidayextras.co.uk/ui-toolkit/">
+          <section>
+            <h2>UI-Toolkit</h2>
+            <div class="project-summary">
+              <blockquote>A collection of styled components built with React</blockquote>
+            </div>
+          </section>
+        </a>
+      </li>
     </ul>
   </main>
 </div>


### PR DESCRIPTION
Does exactly what it says on the tin! Fills in the empty 'slot' in the projects page to go to ui-toolkit page.

#### Author
- [ ] I have checked for grammatical errors
- [ ] I have checked for spelling errors
- [ ] All information (technical or otherwise) is correct to my knowledge

#### Editor 1
- [ ] I have checked for grammatical errors
- [ ] I have checked for spelling errors
- [ ] All information (technical or otherwise) is correct to my knowledge

#### Editor 2
- [ ] I have checked for grammatical errors
- [ ] I have checked for spelling errors
- [ ] All information (technical or otherwise) is correct to my knowledge

