### PR TITLE
Increase size of h2, h3 and h4 headings

### DIFF
--- a/_sass/critical.scss
+++ b/_sass/critical.scss
@@ -25,6 +25,17 @@ h1 {
   font-size:2.5em;
   font-weight:200;
 }
+
+h2 {
+  font-size: 1.9em;
+}
+h3 {
+  font-size: 1.5em;
+}
+h4 {
+  font-size: 1.25em
+}
+
 p {
   padding:.5em 0;
 }


### PR DESCRIPTION
Set size of `h2`, `h3` and `h4` headings to override the user agent defaults. This increases the size of these headings slightly throughout (including article listings) apart from the few places where they were already set.

After this change:
![2017-05-08_10-18-44](https://cloud.githubusercontent.com/assets/12542645/25798286/781d6560-33d8-11e7-90ec-4655b8a84347.png)
