### PR TITLE
Site failed to redeploy due to liquid using different syntax for elseif

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -37,7 +37,7 @@
     <meta name="twitter:site" content="@TheHungryGeek" />
     <meta name="twitter:title" content="{{ page.title }}" />
     <meta name="twitter:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html }}{% else %}All the latest tech news and updates from The Tech Team @ Holiday Extras.{% endif %}" />
-    <meta name="twitter:image" content="{% if page.image %}{{ page.image }}{% elseif author.gravatar_md5 %}http://www.gravatar.com/avatar/{{ author.gravatar_md5 }}?s=144{% endif %}" />
+    <meta name="twitter:image" content="{% if page.image %}{{ page.image }}{% elsif author.gravatar_md5 %}http://www.gravatar.com/avatar/{{ author.gravatar_md5 }}?s=144{% endif %}" />
     <meta name="twitter:image:alt" content="{% if page.image_alt %}{{ page.image_alt}}{{% else %}}{{page.title}} by {{autor.name}}{% endif %}" />
 
 


### PR DESCRIPTION
Liquid for some reason decides to use `elsif` to determine an `else if` block...

![](https://media.giphy.com/media/1M9fmo1WAFVK0/giphy.gif)

This fixes a problem with the twitter meta tags not working with my last PR