### PR TITLE
Layout tweaks to homepage and new update layout

### DIFF
--- a/_includes/styles.scss
+++ b/_includes/styles.scss
@@ -1,5 +1,6 @@
 @import "variables";
 @import "critical"; /* this needs to be refactored a little */
+@import "index";
 @import "structure";
 @import "header";
 @import "footer";

--- a/_layouts/update.html
+++ b/_layouts/update.html
@@ -1,0 +1,20 @@
+---
+layout: default
+category: update
+---
+<article class="post" itemscope itemType="http://schema.org/BlogPosting">
+  <header class="post-header">
+    {% if page.title %}
+      <h1 class="post-title" itemprop="name headline">{{ page.title }}</h1>
+    {% endif %}
+  </header>
+  <div class="container">
+    <div class="post-content" itemprop="articleBody">
+      {{ content }}
+    </div>
+    <small class="tags"><b>Tags</b> <span itemprop="about keywords">{{page.tags | join: ', '}}</span></small>
+    {% if page.comments %}
+      {% include disqus.html %}
+    {% endif %}
+  </div>
+</article>

--- a/_sass/index.scss
+++ b/_sass/index.scss
@@ -1,0 +1,19 @@
+ul.posts li a section i.icon {
+  font-size: 2em;
+  font-family: FontAwesome;
+  text-align: center;
+  vertical-align: middle;
+  border-radius: 50%;
+  margin-bottom: 0;
+  padding: 0;
+  font-style: normal;
+}
+i.icon.quote::before {
+  content: "\f10d";
+}
+i.icon.post::before {
+  content: "\f1ea";
+}
+i.icon.update::before {
+  content: "\f0a1";
+}

--- a/index.html
+++ b/index.html
@@ -13,26 +13,38 @@ category: blog
   <main class="container">
     <ul class="posts">
       {% for post in paginator.posts %}
-      <li>
-        <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/'}}">
-          <section>
-            <h2>{{ post.title }}</h2>
-            <!--<small class="tags"><b>Tags:</b> {{ post.tags | join: ' '}}</small>- No point having these until we can filter by them -->
-            <div class="blog-summary">
-              <blockquote>{{ post.excerpt | strip_html | truncatewords: 50}}</blockquote>
-              {% assign author = site.data.members.[post.author] %}
-              <div class="author">
-                {% if author.gravatar_md5 %}
-                  <img src="http://www.gravatar.com/avatar/{{ author.gravatar_md5 }}?s=200" alt="A photo of {{ member.name }}" />
-                {% else %}
-                  <img src="{{ site.url }}{{ site.baseurl }}/assets/img/avatar-default_360.png" alt="A photo of {{ member.name }}" />
+        <li>
+          <a href="{{ post.url | prepend: site.baseurl | replace: '//', '/'}}">
+            <section>
+              <i class="icon {{ post.layout}}"></i>
+              {% if post.layout == 'post' %}
+                <h2>{{ post.title }}</h2>
+              {% endif %}
+              <!--<small class="tags"><b>Tags:</b> {{ post.tags | join: ' '}}</small>- No point having these until we can filter by them -->
+              <div class="blog-summary">
+                {% assign excerpt = post.excerpt | strip_html %}
+                {% assign excerpt_length = excerpt | number_of_words %}
+                <blockquote>{{ excerpt | truncatewords: 50 }}</blockquote>
+                {% if excerpt_length > 50 %}
+                  <button href="{{ post.url | prepend: site.baseurl | replace: '//', '/'}}" class="btn-info center">
+                    See more...
+                  </button>
                 {% endif %}
-                <div class="author-details">By {{ author.name }}<br/>{{ post.date | date: "%-d %B %Y"}}</div>
+                {% assign author = site.data.members.[post.author] %}
+                {% if post.layout == 'post' %}
+                  <div class="author">
+                    {% if author.gravatar_md5 %}
+                      <img src="http://www.gravatar.com/avatar/{{ author.gravatar_md5 }}?s=200" alt="A photo of {{ member.name }}" />
+                    {% else %}
+                      <img src="{{ site.url }}{{ site.baseurl }}/assets/img/avatar-default_360.png" alt="A photo of {{ member.name }}" />
+                    {% endif %}
+                    <div class="author-details">By {{ author.name }}<br/>{{ post.date | date: "%-d %B %Y"}}</div>
+                  </div>
+                {% endif %}
               </div>
-            </div>
-          </section>
-        </a>
-      </li>
+            </section>
+          </a>
+        </li>
       {% endfor %}
     </ul>
     <!-- Pagination links -->


### PR DESCRIPTION
Added a new update layout. This is similar to posts but without any of the author references. This will be used mainly for small pod updates or other updates that don't require a massive blog post or article.

Also made some modifications to the index page as follows:
- Only posts will show the title and author
- Different type of posts will get different icons
- If the excerpt is longer than 50 words, a see more button will render linking to the full post

![](https://media.giphy.com/media/lr17pFQ95dtdu/giphy.gif)